### PR TITLE
Use templates for sidebar and footer

### DIFF
--- a/2016NYC.html
+++ b/2016NYC.html
@@ -13,37 +13,9 @@
   </head>
   <body>
     <div class="wrapper">
-      <header>
-        <h1><a href="index.html">Gaia Sprints</a></h1>
-	<table>
-	  <tr>
-	    <th>url:</th>
-	    <td><a href="http://gaia.lol">http://gaia.lol</a></td>
-	  </tr>
-	  <tr>
-	    <th>hashtag:</th>
-	    <td><a href="https://twitter.com/hashtag/GaiaSprint">#GaiaSprint</a></td>
-	  </tr>
-	</table>
-        <p>A project to support exploration and scientific use of the
-          <a href="http://www.cosmos.esa.int/web/gaia/release"><i>Gaia</i>
-          Data Releases</a>.</p>
+      
+      {% include_relative sidebar.html %}	    
 
-        <div class="card">
-          <h2><a href="index.html#2017HD">2017 Heidelberg Gaia Sprint</a></h2>
-	  <p><b>2017 July 17 through 21</b></p>
-          <p>At the <a href="http://www.iwh.uni-hd.de/index_engl.html">Internationales
-          Wissenschaftsforum Heidelberg</a>. <i>More information coming soon!</i></p>
-	</div>
-
-        <div class="card">
-          <h2><a href="2016NYC.html">2016 NYC Gaia Sprint</a></h2>
-	  <p><b>2016 October 17 through 21</b></p>
-          <p>At the <a href="https://www.simonsfoundation.org/">Simons Foundation</a>
-	    Center for Computational Astrophysics.</p>
-	</div>
-
-      </header>
       <section>
 
     <h2>2016 NYC Gaia Sprint</h2><a id="2016NYC"></a>
@@ -108,15 +80,7 @@
 
     </section>
 
-      <section>
-        <p class="de-emphasize">This page is maintained by <a
-          href="https://github.com/davidwhogg">davidwhogg</a> and <a
-          href="https://github.com/adrn">adrn</a> as part of the
-          project <a href="https://github.com/davidwhogg/GaiaSprint">davidwhogg/GaiaSprint</a>.
-          The <a href="http://validator.w3.org/check?uri=referer">valid HTML</a>
-	  and <a href="http://jigsaw.w3.org/css-validator/check/referer">valid CSS</a> are
-	  modified versions of <a href="https://github.com/orderedlist">orderedlist</a>.</p>
-      </section>
+    {% include_relative footer.html %} 
 
     </div>
     <script src="javascripts/scale.fix.js"></script>

--- a/codeofconduct.html
+++ b/codeofconduct.html
@@ -13,37 +13,9 @@
   </head>
   <body>
     <div class="wrapper">
-      <header>
-        <h1><a href="index.html">Gaia Sprints</a></h1>
-	<table>
-	  <tr>
-	    <th>url:</th>
-	    <td><a href="http://gaia.lol">http://gaia.lol</a></td>
-	  </tr>
-	  <tr>
-	    <th>hashtag:</th>
-	    <td><a href="https://twitter.com/hashtag/GaiaSprint">#GaiaSprint</a></td>
-	  </tr>
-	</table>
-        <p>A project to support exploration and scientific use of the
-          <a href="http://www.cosmos.esa.int/web/gaia/release"><i>Gaia</i>
-          Data Releases</a>.</p>
+      
+      {% include_relative sidebar.html %}	    
 
-        <div class="card">
-          <h2><a href="index.html#2017HD">2017 Heidelberg Gaia Sprint</a></h2>
-	  <p><b>2017 July 17 through 21</b></p>
-          <p>At the <a href="http://www.iwh.uni-hd.de/index_engl.html">Internationales
-          Wissenschaftsforum Heidelberg</a>. <i>More information coming soon!</i></p>
-	</div>
-
-        <div class="card">
-          <h2><a href="2016NYC.html">2016 NYC Gaia Sprint</a></h2>
-	  <p><b>2016 October 17 through 21</b></p>
-          <p>At the <a href="https://www.simonsfoundation.org/">Simons Foundation</a>
-	    Center for Computational Astrophysics.</p>
-	</div>
-
-      </header>
       <section>
 
     <h2>Gaia Sprint Codes of Conduct</h2><a id="2016NYC"></a>
@@ -104,15 +76,7 @@
 
     </section>
 
-      <section>
-        <p class="de-emphasize">This page is maintained by <a
-          href="https://github.com/davidwhogg">davidwhogg</a> and <a
-          href="https://github.com/adrn">adrn</a> as part of the
-          project <a href="https://github.com/davidwhogg/GaiaSprint">davidwhogg/GaiaSprint</a>.
-          The <a href="http://validator.w3.org/check?uri=referer">valid HTML</a>
-	  and <a href="http://jigsaw.w3.org/css-validator/check/referer">valid CSS</a> are
-	  modified versions of <a href="https://github.com/orderedlist">orderedlist</a>.</p>
-      </section>
+    {% include_relative footer.html %}
 
     </div>
     <script src="javascripts/scale.fix.js"></script>

--- a/footer.html
+++ b/footer.html
@@ -1,0 +1,10 @@
+<section>
+  <p class="de-emphasize">This page is maintained by <a
+    href="https://github.com/davidwhogg">davidwhogg</a> and <a
+    href="https://github.com/adrn">adrn</a> and <a
+    href="https://github.com/andycasey>andycasey</a> as part of the
+    project <a href="https://github.com/davidwhogg/GaiaSprint">davidwhogg/GaiaSprint</a>.
+    The <a href="http://validator.w3.org/check?uri=referer">valid HTML</a>
+    and <a href="http://jigsaw.w3.org/css-validator/check/referer">valid CSS</a> are
+    modified versions of <a href="https://github.com/orderedlist">orderedlist</a>.</p>
+</section>

--- a/index.html
+++ b/index.html
@@ -13,37 +13,9 @@
   </head>
   <body>
     <div class="wrapper">
-      <header>
-        <h1>Gaia Sprints</h1>
-	<table>
-	  <tr>
-	    <th>url:</th>
-	    <td><a href="http://gaia.lol">http://gaia.lol</a></td>
-	  </tr>
-	  <tr>
-	    <th>hashtag:</th>
-	    <td><a href="https://twitter.com/hashtag/GaiaSprint">#GaiaSprint</a></td>
-	  </tr>
-	</table>
-        <p>A project to support exploration and scientific use of the
-          <a href="http://www.cosmos.esa.int/web/gaia/release"><i>Gaia</i>
-          Data Releases</a>.</p>
-
-        <div class="card">
-          <h2><a href="#2017HD">2017 Heidelberg Gaia Sprint</a></h2>
-	  <p><b>2017 July 17 through 21</b></p>
-          <p>At the <a href="http://www.iwh.uni-hd.de/index_engl.html">Internationales
-          Wissenschaftsforum Heidelberg</a>. <i>More information coming soon!</i></p>
-	</div>
-
-        <div class="card">
-          <h2><a href="2016NYC.html">2016 NYC Gaia Sprint</a></h2>
-	  <p><b>2016 October 17 through 21</b></p>
-          <p>At the <a href="https://www.simonsfoundation.org/">Simons Foundation</a>
-	    Center for Computational Astrophysics.</p>
-	</div>
-
-      </header>
+      
+      {% include_relative sidebar.html %}
+	    
       <section>
 
 	<p>If you are interested in attending the <b>2017 Heidelberg Gaia
@@ -128,15 +100,7 @@
 
     </section>
 
-      <section>
-        <p class="de-emphasize">This page is maintained by <a
-          href="https://github.com/davidwhogg">davidwhogg</a> and <a
-          href="https://github.com/adrn">adrn</a> as part of the
-          project <a href="https://github.com/davidwhogg/GaiaSprint">davidwhogg/GaiaSprint</a>.
-          The <a href="http://validator.w3.org/check?uri=referer">valid HTML</a>
-	  and <a href="http://jigsaw.w3.org/css-validator/check/referer">valid CSS</a> are
-	  modified versions of <a href="https://github.com/orderedlist">orderedlist</a>.</p>
-      </section>
+    {% include_relative footer.html %}
 
     </div>
     <script src="javascripts/scale.fix.js"></script>

--- a/sidebar.html
+++ b/sidebar.html
@@ -1,0 +1,30 @@
+<header>
+  <h1><a href="index.html">Gaia Sprints</a></h1>
+  <table>
+    <tr>
+      <th>url:</th>
+      <td><a href="http://gaia.lol">http://gaia.lol</a></td>
+    </tr>
+    <tr>
+      <th>hashtag:</th>
+      <td><a href="https://twitter.com/hashtag/GaiaSprint">#GaiaSprint</a></td>
+    </tr>
+  </table>
+      <p>A project to support exploration and scientific use of the
+        <a href="http://www.cosmos.esa.int/web/gaia/release"><i>Gaia</i>
+        Data Releases</a>.</p>
+
+      <div class="card">
+        <h2><a href="index.html#2017HD">2017 Heidelberg Gaia Sprint</a></h2>
+    <p><b>2017 July 17 through 21</b></p>
+        <p>At the <a href="http://www.iwh.uni-hd.de/index_engl.html">Internationales
+        Wissenschaftsforum Heidelberg</a>. <i>More information coming soon!</i></p>
+  </div>
+
+      <div class="card">
+        <h2><a href="2016NYC.html">2016 NYC Gaia Sprint</a></h2>
+    <p><b>2016 October 17 through 21</b></p>
+        <p>At the <a href="https://www.simonsfoundation.org/">Simons Foundation</a>
+      Center for Computational Astrophysics.</p>
+  </div>
+</header>


### PR DESCRIPTION
Create templates for sidebar and footer (sidebar.html and footer.html) and use `relative_include` to show them on `{index,codeofconduct,2016NYC}.html`

This should work, but there was no way for me to test that the page would generate correctly.. 

#23 can be closed if the pages generate properly after this PR is merged