### PR TITLE
Add papers where contributions were made during 2016 NYC Sprint

### DIFF
--- a/2016NYC.html
+++ b/2016NYC.html
@@ -18,6 +18,16 @@ layout: default
         which <i>incredibly telegraphically</i> summarize the
     accomplishments of the participants.</p>
 
+  <p>The 2016 NYC Gaia Sprint has in part resulted in the following publications:</p> 
+
+  <ul>
+    <li><a href="https://arxiv.org/abs/1612.02440">Co-moving stars in Gaia DR1: An abundance of very wide separation co-moving pairs</a>, Semyeong Oh, Adrian M. Price-Whelan, David W. Hogg, Timothy D. Morton, David N. Spergel
+    <li><a href="https://arxiv.org/abs/1611.04614">Clouds, Streams and Bridges. Redrawing the blueprint of the Magellanic System with Gaia DR1</a>, Vasily Belokurov, Denis Erkal, Alis J. Deason, Sergey E. Koposov, Francesca De Angeli, Dafydd Wyn Evans, Filippo Fraternali, Dougal Mackey</li>
+    <li><a href="https://arxiv.org/abs/1611.07035">A Probabilistic Approach to Fitting Period-Luminosity Relations and Validating Gaia Parallaxes</a>, Branimir Sesar, Morgan Fouesneau, Adrian M. Price-Whelan, Coryn A. L. Bailer-Jones, Andy Gould, Hans-Walter Rix</li>
+    <li><a href="https://arxiv.org/abs/1610.08563">Rotating Stars from Kepler Observed with Gaia DR1</a>, James R. A. Davenport</li>
+    <li><a href="https://arxiv.org/abs/1610.07610">Galactic rotation in Gaia DR1</a>, Jo Bovy</li>
+  </ul>
+
   <h3>Organizing Committee</h3>
   <ul><li><b>Ana Bonaca</b> (Yale)</li>
       <li><b>Andy Casey</b> (Cambridge)</li>


### PR DESCRIPTION
I added papers (listed by @adrn) where contributions were made during the 2016 NYC Gaia Sprint.

I will consider any minor text edit, and accept almost all of them.

#31 can be closed when this is merged.