### PR TITLE
Remove custom Code of Conduct, use AAS Code of Ethics

### DIFF
--- a/codeofconduct.html
+++ b/codeofconduct.html
@@ -4,43 +4,19 @@ layout: default
 
 <h2>Gaia Sprint Codes of Conduct</h2><a id="2016NYC"></a>
 
-  <p><i>There are two codes of conduct applicable to the Gaia Sprints.</i></p>
-
   <h3>General Code of Conduct</h3>
   <p>The Gaia Sprints organizers are dedicated to providing a
     harassment-free conference experience for everyone,
     regardless of gender, gender identity and expression, age,
     sexual orientation, disability, physical appearance, body
     size, race, ethnicity, religion (or lack thereof), or
-    technology choices. We do not tolerate harassment of
-    conference participants in any form. Sexual language and
-    imagery is not appropriate for any conference venue,
-    including talks, workshops, parties, Twitter and other
-    online media. Participants violating these rules may be
-    sanctioned or expelled from the Gaia Sprint without a refund
-    at the discretion of the conference organizers.</p>
-  <p>Harassment includes offensive verbal comments related to
-    gender, gender identity and expression, age, sexual
-    orientation, disability, physical appearance, body size,
-    race, ethnicity, religion, technology choices, sexual images
-    in public spaces, deliberate intimidation, stalking,
-    following, harassing photography or recording, sustained
-    disruption of talks or other events, inappropriate physical
-    contact, and unwelcome sexual attention.</p>
-  <p>Participants asked to stop any harassing behavior are
-    expected to comply immediately. If a participant engages in
-    harassing behavior, the organizers may take any action they
-    deem appropriate, including warning the offender or
-    expulsion from the Gaia Sprint with no refund.</p>
-  <p>If you are being harassed, notice that someone else is
-    being harassed, or have any other concerns, please contact
-    an organizer immediately. Organizers will be happy to help
-    participants contact local law enforcement, provide escorts,
-    or otherwise assist those experiencing harassment to feel
-    safe for the duration of the Gaia Sprint. We value your
-    attendance.</p>
-  <p>We expect participants to follow these rules during the
-    Gaia Sprint and during related social events.</p>
+    technology choices.
+    We do not tolerate harassment, abusive behavior, or intimidation of
+    conference participants in any form.
+    As such, we follow the <a href="https://aas.org/ethics">AAS Code of
+    Ethics</a>, and expect all participants to read and abide by the statements
+    in the <a href="https://aas.org/ethics">AAS Code of Ethics</a>.
+  </p>
 
   <h3>Collaboration Policy</h3>
   <p>All participants at every Gaia Sprint will be expected to openly
@@ -57,3 +33,5 @@ layout: default
     data sets or proprietary code</i> to any Sprint, unless the
     participant bringing such assets has the rights to open them
     or add collaborators.</p>
+  <p>We additionally ask participants to abide by the <i>Research</i> and
+    <i>Publication and Authorship</i> guidelines of the <a href="https://aas.org/ethics">AAS Code of Ethics</a>.


### PR DESCRIPTION
I've removed our own custom code of conduct in favor of the more extensive and standard Code of Ethics adopted by the AAS.