### PR TITLE
Add Seattle 2018 satellite meeting page

### DIFF
--- a/2018SEA.html
+++ b/2018SEA.html
@@ -1,0 +1,69 @@
+---
+layout: default
+---
+
+<h2>2018 Gaia Sprint: Seattle </h2><a id="2018HD"></a>
+
+  <h3>Applications are now closed for the 2018 NYC Gaia Sprint</h3>
+  <p>If you applied, <i>you should have received email</i> by now
+     letting you know whether you have been admitted to the Sprint.
+     Let us know if you did not receive that email.
+     Apologies to those we could not admit: We were highly over-subscribed!</p>
+
+  <h3>Schedule and Location</h3>
+  <p> The 2018 Seattle <b>Satellite</b> meeting will take place in concert with the official NYC meeting.</p> 
+  <p>The 2018 NYC Gaia Sprint will take place from 2018 June 04 to June 08,
+     inclusive, at the <a href="http://flatironinstitute.org/">Flatiron Institute</a>,
+     a division of the <a href="https://simonsfoundation.org/">Simons Foundation</a>.</p>
+
+
+  <h3>Scientific Organizing Committee</h3>
+  <ul><li><b>Ana Bonaca</b> (Harvard)</li>
+      <li><b>Andy Casey</b> (Monash)</li>
+      <li><b>David W. Hogg</b> (NYU) (MPIA) (Flatiron), <i>Organizing Committee Chair</i></li>
+      <li><b>Adrian Price-Whelan</b> (Princeton)</li>
+      <li><b>Hans-Walter Rix</b> (MPIA)</li>
+      <li><b>David Spergel</b> (Flatiron) (Princeton)</li>
+      <li><b>Wilma Trick</b> (MPA)</li>
+  </ul>
+
+  <h3>Local Organizing Committee</h3>
+  <ul><li><b>Jocelyn Dorszynski</b> (Flatiron)</li>
+      <li><b>David W. Hogg</b> (NYU) (MPIA) (Flatiron)</li>
+  </ul>
+
+<h3>Objectives</h3>
+  <p>The idea behind the Sprints is to bring together people who
+    have an interest in timely scientific investigation and use
+    of the <i>Gaia</i> Data.  These are not traditional
+    scientific meetings; they are intended to facilitate
+    completion of first scientific papers.  The Sprints are
+    structured to support collaborative refinement and execution
+    of (fairly) mature scientific ideas.  It is hoped that new
+    partnerships will form and lead to co-authored publications
+    for the scientific literature ready or near-ready by the end
+    of each Sprint.</p>
+
+<h3>Collaboration Policy</h3>
+  <p><i>In addition to a general <a href="codeofconduct.html">Code
+    of Conduct</a>, we require participants to agree to a
+    Collaboration Policy that ensures transparency and openness
+    at the Sprints:</i></p>
+  <p>All participants at every Gaia Sprint will be expected to openly
+    share their ideas, expertise, code, and interim results.
+    Project development will proceed out in the open, among
+    participants and in the world.</p>
+  <p>Participants will be encouraged to change gears, start new
+    collaborations, and combine projects.  Any participant who
+    contributes significantly to a project can expect
+    co-authorship on resulting scientific papers, and any
+    participant who gets signficant contributions to a project
+    is expected to include those contributors as co-authors.</p>
+  <p>These rules make it <i>inadvisable to bring proprietary
+    data sets or proprietary code</i> to any Sprint, unless the
+    participant bringing such assets has the rights to open them
+    or add collaborators.</p>
+
+<h2>Parent event:</h2>
+
+  <h3>&bullet; <a href="2018NYC.html">2018 NYC Gaia Sprint</a></h3>

--- a/2018SEA.html
+++ b/2018SEA.html
@@ -2,37 +2,31 @@
 layout: default
 ---
 
-<h2>2018 Gaia Sprint: Seattle </h2><a id="2018HD"></a>
+<h2>2018 Gaia Sprint: Seattle Satellite</h2><a id="2018HD"></a>
 
-  <h3>Applications are now closed for the 2018 NYC Gaia Sprint</h3>
-  <p>If you applied, <i>you should have received email</i> by now
+  <!-- <h3>Applications are now closed for the 2018 NYC Gaia Sprint</h3> -->
+  <!-- <p>If you applied, <i>you should have received email</i> by now
      letting you know whether you have been admitted to the Sprint.
      Let us know if you did not receive that email.
-     Apologies to those we could not admit: We were highly over-subscribed!</p>
+     Apologies to those we could not admit: We were highly over-subscribed!</p> -->
 
   <h3>Schedule and Location</h3>
-  <p> The 2018 Seattle <b>Satellite</b> meeting will take place in concert with the official NYC meeting.</p> 
-  <p>The 2018 NYC Gaia Sprint will take place from 2018 June 04 to June 08,
-     inclusive, at the <a href="http://flatironinstitute.org/">Flatiron Institute</a>,
-     a division of the <a href="https://simonsfoundation.org/">Simons Foundation</a>.</p>
-
-
-  <h3>Scientific Organizing Committee</h3>
-  <ul><li><b>Ana Bonaca</b> (Harvard)</li>
-      <li><b>Andy Casey</b> (Monash)</li>
-      <li><b>David W. Hogg</b> (NYU) (MPIA) (Flatiron), <i>Organizing Committee Chair</i></li>
-      <li><b>Adrian Price-Whelan</b> (Princeton)</li>
-      <li><b>Hans-Walter Rix</b> (MPIA)</li>
-      <li><b>David Spergel</b> (Flatiron) (Princeton)</li>
-      <li><b>Wilma Trick</b> (MPA)</li>
-  </ul>
+  <p> The 2018 <b>Seattle Satellite</b> meeting will take place at the
+    University of Washington from 2018 June 04 to June 08,
+    inclusive, in concert with the official <a href="2018NYC.html"> NYC Sprint</a>.</p>
 
   <h3>Local Organizing Committee</h3>
-  <ul><li><b>Jocelyn Dorszynski</b> (Flatiron)</li>
+  <ul><li><b>James R. A. Davenport</b> (UW)</li>
       <li><b>David W. Hogg</b> (NYU) (MPIA) (Flatiron)</li>
   </ul>
 
 <h3>Objectives</h3>
+<p> In organizing the Satellite Sprint, we hope to 1) open the
+  Gaia Sprint experience up to a larger audience, and 2) experiment
+  with new ways of hosting engaging and useful collaborations in
+  distributed locations simultaneously. The same objectives and rules
+  of collaboration and participation apply at the Satellite Sprint. </p>
+
   <p>The idea behind the Sprints is to bring together people who
     have an interest in timely scientific investigation and use
     of the <i>Gaia</i> Data.  These are not traditional
@@ -43,6 +37,7 @@ layout: default
     partnerships will form and lead to co-authored publications
     for the scientific literature ready or near-ready by the end
     of each Sprint.</p>
+
 
 <h3>Collaboration Policy</h3>
   <p><i>In addition to a general <a href="codeofconduct.html">Code


### PR DESCRIPTION
Create simple SEA 2018 page, with style copied from NYC 2018 meeting.