### PR TITLE
Satellite papers

### DIFF
--- a/2018NYC.html
+++ b/2018NYC.html
@@ -21,9 +21,13 @@ layout: default
     <a href="https://speakerdeck.com/dwhgg/2018-nyc-gaia-sprint-wrap-up-slides">2018 NYC Gaia Sprint <b>Wrap-up Slides</b></a>, 
     which summarize the accomplishments made throughout the week.</p>
 
-  <p>The 2018 NYC Gaia Sprint has in part resulted in the following publications:</p>
+  <p>The 2018 NYC Gaia Sprint and its satellite events in
+      <a href="2018SEA.html">SEA</a> and 
+      <a href="2018SB.html">SB</a>
+     have in part resulted in the following publications:</p>
 
   <ul>
+    <li><a href="https://arxiv.org/pdf/1807.09841">Rotating stars from Kepler observed with Gaia DR2</a>, James R. A. Davenport and Kevin Covey</li>
     <li><a href="https://arxiv.org/abs/1807.06011">Imprints of white dwarf recoil in the separation distribution of Gaia wide binaries</a>, Kareem El-Badry and Hans-Walter Rix</li>
     <li><a href="https://arxiv.org/abs/1806.02832">Transient spiral structure and the disc velocity substructure in Gaia DR2</a>, Jason A. S. Hunt, Jack Hong, Jo Bovy, Daisuke Kawata, Robert Grand</li>
     <li><a href="http://iopscience.iop.org/article/10.3847/2515-5172/aacd17/meta">Lucky Star: Confirming the Distance to USNO-A0600-15865535 and High-velocity Cloud Complex WD</a>J. E. G. Peek, Rongmon Bordoloi, Hugues Sana, Julia Roman-Druval, Jason Tumlinson, Yong Zheng</li>

--- a/2018SB.html
+++ b/2018SB.html
@@ -27,6 +27,9 @@ layout: default
     which summarize the accomplishments made throughout the week.</p>
   -->
 
+  <p>Publications that have in part resulted from the 2018 Gaia Sprint: Santa
+     Barbara Satellite are listed on the 
+     <a href="2018NYC.html">2018 NYC Gaia Sprint</a> page.</p>
 
   <h3>Local Organizing Committee</h3>
   <ul><li><b>Juna Kollmeier</b> (Carnegie)</li>

--- a/2018SEA.html
+++ b/2018SEA.html
@@ -23,7 +23,9 @@ layout: default
   <p>On the last day, the wrap up was given from a jointly edited set of
     <a href="https://docs.google.com/presentation/d/16plKdsb-ywCu3Jwvtn7re67AhT3ED-0j2G0n6NUYDyA/edit?usp=sharing">2018 Gaia Sprint: Seattle Satellite <b>Wrap-up Slides</b></a>, 
     which summarize the accomplishments made throughout the week.</p>
-
+  <p>Publications that have in part resulted from the 2018 Gaia Sprint: Seattle
+     Satellite are listed on the <a href="2018NYC.html">2018 NYC Gaia Sprint</a>
+     page.</p>
 
   <h3>Local Organizing Committee</h3>
   <ul><li><b>James R. A. Davenport</b> (UW)</li>


### PR DESCRIPTION
This PR addresses papers that result in part from satellite Sprints.

I added Davenport & Covey (2018) paper that resulted from the SEA satellite sprint on the 2018 NYC parent sprint page. I updated the language on the 2018 NYC sprint page to state these are papers resulting from NYC and satellite sprints, and added links on the satellite pages to the parent page.

This PR is to for @davidwhogg to check language and format.