### PR TITLE
Add a new page for dr3 event

### DIFF
--- a/2022NYC.html
+++ b/2022NYC.html
@@ -2,35 +2,34 @@
 layout: default
 ---
 
-<h2>2021 NYC Gaia Sprint</h2><a id="2021"></a>
+<h2>2022 NYC Gaia DR3 Fête</h2><a id="2022"></a>
 
   <h3>Schedule and Location</h3>
-  <p>The <b>2021 NYC Gaia Sprint</b> meeting will take place at the
+  <p>The <b>2022 NYC Gaia DR3 Fête</b> will take place at the
       <a href="http://flatironinstitute.org/">Flatiron Institute</a>,
-      a division of the <a href="https://simonsfoundation.org/">Simons Foundation</a>.</i></p>
+      a division of the <a href="https://simonsfoundation.org/">Simons
+      Foundation</a>. Dates are currently TBD, but will coincide with <a
+      href="https://www.cosmos.esa.int/web/gaia/data-release-3">Gaia DR3</a>.
+  </p>
 
   <h3>Objectives</h3>
-    <p>The idea behind the Sprints is to bring together people who
-    have an interest in timely scientific investigation and use
-    of the <i>Gaia</i> Data.  These are not traditional
-    scientific meetings; they are intended to facilitate
-    completion of first scientific papers.  The Sprints are
-    structured to support collaborative refinement and execution
-    of (fairly) mature scientific ideas.  It is hoped that new
-    partnerships will form and lead to co-authored publications
-    for the scientific literature ready or near-ready by the end
-    of each Sprint.</p>
+    <p>The principal aim of the Fête is to gather a community of people who
+      are actively thinking about Gaia science to develop and work on projects,
+      visualizations, and explorations of data released in Gaia DR3. While
+      there is no scientific focus, the theme of the Fête is <i>stellar
+      spectroscopy</i>, as
+      <a href="https://www.cosmos.esa.int/web/gaia/data-release-3">DR3 will
+        provide entirely new kinds of data</a> (compared to past Gaia data
+      releases) in the form of moderate-resolution spectra with a small
+      wavelength range (the RVS spectra) and low-resolution spectra with wide
+      wavelength coverage (the BP/RP spectra).
+    </p>
 
 
-  <h3>Scientific Organizing Committee</h3>
+  <h3>Organizing Committee</h3>
     <ul>
       <li><b>David W Hogg</b> (NYU) (MPIA) (Flatiron), <i>Organizing Committee Chair</i></li>
-      <li><i>and friends</i></li>
-    </ul>
-
-  <h3>Local Organizing Committee</h3>
-    <ul>
-      <li><b>David W Hogg</b> (NYU) (MPIA) (Flatiron)</li>
+      <li><b>Adrian Price-Whelan</b> (Flatiron), </li>
       <li><i>and friends</i></li>
     </ul>
 
@@ -38,7 +37,7 @@ layout: default
     <p><i>In addition to a general <a href="codeofconduct.html">Code
     of Conduct</a>, we require participants to agree to a
     Collaboration Policy that ensures transparency and openness
-    at the Sprints:</i></p>
+    at the Sprints and associated meetings:</i></p>
     <p>All participants at every Gaia Sprint will be expected to openly
     share their ideas, expertise, code, and interim results.
     Project development will proceed out in the open, among
@@ -47,10 +46,9 @@ layout: default
     collaborations, and combine projects.  Any participant who
     contributes significantly to a project can expect
     co-authorship on resulting scientific papers, and any
-    participant who gets signficant contributions to a project
+    participant who gets significant contributions to a project
     is expected to include those contributors as co-authors.</p>
     <p>These rules make it <i>inadvisable to bring proprietary
     data sets or proprietary code</i> to any Sprint, unless the
     participant bringing such assets has the rights to open them
     or add collaborators.</p>
-  

--- a/index.html
+++ b/index.html
@@ -1,1 +1,1 @@
-2021NYC.html
+2022NYC.html


### PR DESCRIPTION
This also removes the 2021 sprint page, since it didn't happen!