### PR TITLE
Add page for 2026 NYC Gaia DR4 Sprint 

### DIFF
--- a/2026NYC.html
+++ b/2026NYC.html
@@ -1,0 +1,75 @@
+---
+layout: default
+---
+
+<h2>2026 NYC Gaia DR4 Sprint</h2><a id="2026"></a>
+
+  <h3>Schedule and Location</h3>
+  <p>The <b>2026 NYC Gaia DR4 Sprint</b> will take place in December 2026 at the
+      <a href="https://www.simonsfoundation.org/flatiron/center-for-computational-astrophysics/">Center
+      for Computational Astrophysics</a> (CCA), a division of the
+      <a href="http://flatironinstitute.org/">Flatiron Institute</a> of the
+      <a href="https://simonsfoundation.org/">Simons Foundation</a>, in
+      New York City. The exact dates will be anchored on the public release
+      of Gaia DR4.
+  </p>
+
+  <h3>Apply to participate</h3>
+    <p>An application form will be posted here closer to the event.</p>
+
+  <h3>Objectives</h3>
+    <p>
+      The NYC Gaia DR4 Sprint will be a small in-person event gathering at
+      the CCA in New York City around the release date of Gaia DR4. The
+      idea of the event will be to make preliminary, science-inspired
+      visualizations of the Gaia DR4 data and build new scientific
+      collaborations, locally and globally.
+      Gaia DR4 is the <i>full</i> data release from the nominal Gaia mission,
+      and will include — for the first time — epoch-level astrometry,
+      photometry, and spectroscopy, along with the much-anticipated catalog
+      of non-single stars and exoplanet candidates.
+    </p>
+    <p>
+      We expect to be over-subscribed; if we are, we will give some
+      preference to early-career applicants, and try to admit a set of
+      participants that span a range of data applications.
+    </p>
+
+  <h3>Satellite events</h3>
+    <p>
+      We strongly encourage <i>satellite</i> Gaia DR4 Sprints at other
+      institutions around the world, running concurrently with the NYC
+      event. Satellites extend the reach of the Sprint, lower the barrier
+      to participation, and seed new collaborations across time zones.
+      If you are interested in hosting a satellite, please
+      <a href="mailto:david.hogg@nyu.edu">contact the organizers</a> —
+      we would love to help promote your event and coordinate with you.
+    </p>
+
+  <h3>Organizing Committee</h3>
+    <ul>
+      <li><b>David W Hogg</b> (NYU) (MPIA) (Flatiron)</li>
+      <li><b>Jackie Faherty</b> (AMNH)</li>
+      <li><b>Adrian Price-Whelan</b> (Flatiron)</li>
+      <li><b>Andy Casey</b> (Flatiron) (Monash)</li>
+    </ul>
+
+  <h3>Collaboration Policy</h3>
+    <p><i>In addition to a general <a href="codeofconduct.html">Code
+    of Conduct</a>, we require participants to agree to a
+    Collaboration Policy that ensures transparency and openness
+    at the Sprints and associated meetings:</i></p>
+    <p>All participants at every Gaia Sprint will be expected to openly
+    share their ideas, expertise, code, and interim results.
+    Project development will proceed out in the open, among
+    participants and in the world.</p>
+    <p>Participants will be encouraged to change gears, start new
+    collaborations, and combine projects.  Any participant who
+    contributes significantly to a project can expect
+    co-authorship on resulting scientific papers, and any
+    participant who gets significant contributions to a project
+    is expected to include those contributors as co-authors.</p>
+    <p>These rules make it <i>inadvisable to bring proprietary
+    data sets or proprietary code</i> to any Sprint, unless the
+    participant bringing such assets has the rights to open them
+    or add collaborators.</p>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -15,18 +15,20 @@
         The current release is
         <a href="https://www.cosmos.esa.int/web/gaia/edr3"><i>Early Data Release 3</i></a>.</p>
   <div class="card">
-        <h2>next up: the <a href="2022NYC.html">2022 Gaia DR3 Fête</a></h2>
+        <h2>Upcoming: the <a href="2026NYC.html">2026 NYC Gaia DR4 Sprint</a></h2>
   </div>
   <div class="card">
         <h2>Future events:</h2>
     <p>
-      <b><a href="2022NYC.html"><b>2022 Gaia DR3 Fête</b></a></b>
+      <b><a href="2026NYC.html"><b>2026 NYC Gaia DR4 Sprint</b></a></b>
     </p>
   </div>
   <div class="card">
         <h2>Past events:</h2>
     <p>
+    <a href="2022NYC.html"><b>2022 NYC Gaia DR3 Fête</b></a><br />
     <a href="2020unboxing.html"><b>2020 EDR3 Unboxing Gaia Sprint</b></a><br />
+
       <a href="2019SB.html"><b>2019 Santa Barbara Gaia Sprint</b></a><br />
       <a href="2019OXF.html"><b>2019 Gaia Sprint: Oxford Satellite</b></a><br />
       <a href="2019SEA.html"><b>2019 Gaia Sprint: Seattle Satellite</b></a><br />


### PR DESCRIPTION
This PR adds a placeholder page for the 2026 NYC Gaia DR4 Sprint. 

TL;DR:
- Dates and participant numbers not specified
- Satellites explicitly encouraged
- No application form yet
- Placeholder organizing committee is not thoughtfully chosen. It's simply drawn from our email exchanges, and perhaps these people don't even want to be organizers!